### PR TITLE
feat: Add groupRolesList data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Live Examples:
 
 * [Dovedale Wiki](https://dovedale.wiki/)
 * [Hybrid Cafe Wiki](https://hybridcafe.wiki/)
-* [UTG Wiki](https://utg.miraheze.org/)
+* [Untitled Tag Game Wiki](https://utg.miraheze.org/)
 
 ## Installation
 
@@ -29,7 +29,7 @@ Live Examples:
     wfLoadExtension( 'RobloxAPI' );
     ```
 
-Miraheze users may use ManageWiki to install this extension. Search for 'RobloxAPI' in *Special:ManageWiki* and
+Miraheze users may use ManageWiki to install this extension. Search for 'RobloxAPI' in *Special:ManageWiki/extensions* and
 install it with a click.
 
 ## Usage

--- a/USAGE.md
+++ b/USAGE.md
@@ -447,6 +447,24 @@ Get all JSON data of an asset:
 |-----------|----------------------------|------------|
 | `AssetId` | The asset ID of the asset. | Numeric ID |
 
+### groupRolesList
+
+Provides a list of roles in a group in the [JSON format](#Handling-JSON-data).
+
+#### Example
+
+Get the roles of a group:
+
+```
+{{#robloxAPI: groupRolesList | 32670248 }}
+```
+
+#### Required Arguments
+
+| Name      | Description                | Type       |
+|-----------|----------------------------|------------|
+| `GroupId` | The group ID of the group. | Numeric ID |
+
 ## Handling JSON data
 
 ### JSON keys

--- a/extension.json
+++ b/extension.json
@@ -36,7 +36,8 @@
 				"groupMembers",
 				"badgeInfo",
 				"userInfo",
-				"assetDetails"
+				"assetDetails",
+				"groupRolesList"
 			],
 			"merge_strategy": "provide_default",
 			"description": "The data sources that should be enabled and available."

--- a/src/data/source/DataSourceProvider.php
+++ b/src/data/source/DataSourceProvider.php
@@ -75,6 +75,10 @@ class DataSourceProvider {
 			( new ArgumentSpecification( [ 'GroupID' ] ) )->withJsonArgs(), static function ( $args ) {
 				return "https://groups.roblox.com/v1/groups/$args[0]";
 			}, null, true ) );
+		$this->registerDataSource( new SimpleFetcherDataSource( 'groupRolesList', $config,
+			( new ArgumentSpecification( [ 'GroupID' ] ) )->withJsonArgs(), static function ( $args ) {
+				return "https://groups.roblox.com/v1/groups/$args[0]/users";
+			}, null, false ) );
 		$this->registerDataSource( new SimpleFetcherDataSource( 'badgeInfo', $config,
 			( new ArgumentSpecification( [ 'BadgeID' ] ) )->withJsonArgs(), static function ( $args ) {
 				return "https://badges.roblox.com/v1/badges/$args[0]";

--- a/src/data/source/DataSourceProvider.php
+++ b/src/data/source/DataSourceProvider.php
@@ -77,7 +77,7 @@ class DataSourceProvider {
 			}, null, true ) );
 		$this->registerDataSource( new SimpleFetcherDataSource( 'groupRolesList', $config,
 			( new ArgumentSpecification( [ 'GroupID' ] ) )->withJsonArgs(), static function ( $args ) {
-				return "https://groups.roblox.com/v1/groups/$args[0]/users";
+				return "https://groups.roblox.com/v1/groups/$args[0]/roles";
 			}, null, false ) );
 		$this->registerDataSource( new SimpleFetcherDataSource( 'badgeInfo', $config,
 			( new ArgumentSpecification( [ 'BadgeID' ] ) )->withJsonArgs(), static function ( $args ) {


### PR DESCRIPTION
As per #22, adding the groupRolesList data source to fetch a list of roles in a group.

[API Docs](https://groups.roblox.com//docs/index.html?urls.primaryName=Groups%20Api%20v1#operations-Membership-get_v1_groups__groupId__roles)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added `groupRolesList` data source to retrieve roles in a group.

- **Documentation**
	- Updated `USAGE.md` with detailed information about the new `groupRolesList` data source, including usage examples and required argument specifications.

- **Configuration**
	- Updated `extension.json` to include `groupRolesList` in available data sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->