### PR TITLE
chore: add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /vendor
 /node_modules
 .eslintcache
+.DS_Store


### PR DESCRIPTION
This PR adds MacOS's trademark annoying .DS_Store to the .gitignore to ensure no unnecessary or potentially sensitive files are committed to the repo or to forks when developing on MacOS.

I'm currently writing another PR to add a couple of new sources for user avatars (headshots & busts) and this was annoying me.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ignore settings to exclude macOS .DS_Store files, keeping the repository clean and preventing accidental commits of system files.
  * Improves developer workflow and reduces noise in diffs and pull requests.
  * No user-facing changes; application behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->